### PR TITLE
Added svg

### DIFF
--- a/src/Utils/MimeUtil.php
+++ b/src/Utils/MimeUtil.php
@@ -139,6 +139,7 @@ class MimeUtil
             "pgm"     => "image/x-portable-graymap",
             "ppm"     => "image/x-portable-pixmap",
             "rgb"     => "image/x-rgb",
+            "svg"     => "image/svg+xml",
             "xbm"     => "image/x-xbitmap",
             "xpm"     => "image/x-xpixmap",
             "xwd"     => "image/x-windowdump",


### PR DESCRIPTION
There was no image mapping for svg. This allows img tags to have a source with an svg source